### PR TITLE
Updates gulp-metal to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-cli": "^6.4.5",
     "babel-preset-metal": "^4.0.0",
     "gulp": "^3.8.11",
-    "gulp-metal": "^1.0.0",
+    "gulp-metal": "^2.0.0",
     "marble": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hey @pragmaticivan, @eduardolundgren, this will update `gulp-metal` to the latest release (`2.2.1`) which fixes the test issues produced by the `v2.13.0` release of `metal-incremental-dom`.